### PR TITLE
Add Fall 2026 course structure, assessment, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,133 @@
-# 💹 Machine Learning for Finance
+# 💹 Machine Learning for Finance (PhD) — Fall 2026
 
-This course explores the intersection of **machine learning (ML)** and **finance**, with applications in **asset pricing**, **portfolio optimization**, **risk management**, **market microstructure**, and more. You’ll learn modern ML techniques on real financial data and build end-to-end pipelines through hands-on projects.
-
----
-
-## 🧭 Quick Info
-- **Format:** Lectures • Case studies • Hands-on projects
-- **Prereqs:**  
-  - Background in finance or economics  
-  - ML & applied statistics  
-  - Python programming
+This repository contains materials for the PhD-level course **Machine Learning for Finance**. The course studies modern machine-learning methods for financial prediction and decision-making, with applications to empirical asset pricing, market microstructure, portfolio construction, graph learning, reinforcement learning, generative models, large language models, and responsible AI.
 
 ---
 
-## 🗓️ Course Agenda (Dates Removed)
-- **Lec 1 — Intro to Financial ML**  
-  Overview; prices-as-predictions; info sets; functional forms; practical challenges.
-- **Lec 2 — Empirical Asset Pricing I**  
-  Data; experimental design; linear & penalized models; dimension reduction. *(HW1 released)*
-- **Lec 3 — Empirical Asset Pricing II**  
-  Trees & ensembles; neural nets; alternative data (image/text).
-- **Lec 4 — High-Frequency Prediction**  
-  LOB, sampling, order flow, universality, cross impact, spatio-temporal modeling. *(HW2 released)*
-- **Lec 5 — Optimal Portfolios**  
-  Plug-in vs integrated estimation; max-Sharpe regression; trading costs.
-- **Lec 6 — RL in Finance**  
-  RL basics; optimal execution; market making; paper discussion; project proposals.
-- **Lec 7 — Generative AI for Finance**  
-  GANs/VAEs/diffusion; synthetic backtesting; pitfalls; TailGAN/MARS overview.
-- **Lec 8 — Risk via Graphs**  
-  Graph ML; VaR; credit risk (fraud/anomaly/defaults/scoring); systemic risk.
-- **Lec 9 — Large Language Models (LLMs)**  
-  Sentiment; report generation; chatbots; reasoning; challenges.
-- **Lec 10 — Interpretability & Ethics**  
-  🔍 LIME/SHAP; clustering, t-SNE, graph DBs; bias/fairness; compliance.
-- **Lec 11 — Advanced Topics**  
-  Transfer & federated learning; microstructure & stat-arb; backtesting pipeline.
-- **Lec 12 — Case Studies & Labs**  
-  HF prediction, volatility forecasting, LLM apps.
-- **Lec 13 — Final Presentations**
+## 🧭 Course Structure
+
+- **13 lectures**
+- **6 student paper presentations**
+- Presentation weeks include approximately:
+  - 2 hours of instructor lecture
+  - 30 minutes of student presentation
+  - 10–15 minutes of instructor-led discussion
+- **One formal homework:** Asset Pricing
+  - Released after **Lecture 4**
+  - Due after **Lecture 10**
+- **Lecture 12:** Industry guest lecture / practitioner perspectives
+- **Lecture 13:** Final research presentations
+
+Student papers are generally presented one lecture after the relevant methodology has been introduced.
 
 ---
 
-## 🧪 Assignments
-- **HW1 — Cross-Sectional Returns**  
-  Linear regression: strengths/limits; predict U.S. equity returns.
-- **HW2 — High-Frequency Modeling**  
-  Work with LOB data; replicate & analyze **DeepLOB**.
+## 📁 Course Materials
+
+- **Fall 2026:** [`docs/lectures_Fall2026/`](docs/lectures_Fall2026/)
+- **Spring 2026 archive:** [`docs/lectures_Spring2026/`](docs/lectures_Spring2026/)
+- **Spring 2025 archive:** [`docs/lectures_Spring2025/`](docs/lectures_Spring2025/)
+
+Fall 2026 lecture files will be added progressively during the semester.
 
 ---
 
-## 🚀 Final Project
-Pick one—or propose your own (LLM-centric ideas welcome):
+## 🗓️ Fall 2026 Schedule
 
-- **📊 Option 1: Generate OHLC Charts**  
-  *Data:* Historical prices (provided)  
-  *Outcome:* A generative model for OHLC sequences
-- **📉 Option 2: Stat-Arb with LOB Data**  
-  *Data:* Raw **LOBSTER** (provided to enrolled students)  
-  *Outcome:* A data-driven stat-arb strategy
-- **💡 Propose Your Own (LLMs in Finance):**  
-  news summarization • report generation • sentiment for prediction • other LLM apps
-
-**Deliverables:** proposal, code repo, reproducible notebooks, report, and in-class presentation.
+| Lecture | Main Topic | Student Presentation / Other |
+|---|---|---|
+| **Lec 1** | **Introduction to Financial Machine Learning** — overview, information sets, functional forms, and practical challenges in financial prediction | — |
+| **Lec 2** | **Empirical Asset Pricing I** — data, experimental design, linear and penalized models, and dimension reduction | — |
+| **Lec 3** | **Empirical Asset Pricing II** — trees, ensembles, neural networks, nonlinear models, and alternative data / representation learning | — |
+| **Lec 4** | **High-Frequency Prediction** — limit order books, sampling, order flow, universality, cross-impact, and spatio-temporal modeling | **P1: Nonlinear / Representation Learning in Asset Pricing**; Asset Pricing HW released |
+| **Lec 5** | **Optimal Portfolios** — plug-in vs integrated estimation, covariance estimation, max-Sharpe regression, and transaction costs | **P2: High-Frequency / Microstructure ML** |
+| **Lec 6** | **Graph Machine Learning for Finance** — graph representations, GNNs, financial networks, cross-asset dependence, and covariance / volatility applications | **P3: Portfolio Construction / Decision-Focused ML** |
+| **Lec 7** | **Reinforcement Learning in Finance** — RL basics, optimal execution, market making, and sequential decision-making | **P4: Graph ML for Asset Pricing** |
+| **Lec 8** | **Generative AI for Finance** — GANs, VAEs, diffusion models, synthetic backtesting, Tail-GAN / MARS, and pitfalls | — |
+| **Lec 9** | **Large Language Models for Finance** — sentiment, financial text, report generation, QA / chatbots, reasoning, applications, and challenges | **P5: Generative Finance** |
+| **Lec 10** | **Interpretability & Ethics / Responsible ML** — LIME / SHAP, clustering, t-SNE, bias / fairness, and compliance | **P6: LLMs / Foundation Models in Finance**; Asset Pricing HW due after class |
+| **Lec 11** | **Advanced Topics** — transfer learning, federated learning, microstructure / statistical arbitrage, backtesting pipelines, and selected advanced topics | — |
+| **Lec 12** | **Industry Guest Lecture / Practitioner Perspectives** | Guest speaker discussion |
+| **Lec 13** | **Final Research Presentations** | Student final project presentations |
 
 ---
 
-## 🧮 Grading
-- 🗣️ Participation — **10%**  
-- 📝 Course Assignment I — **15%**  
-- 🧾 Course Assignment II — **25%**  
-- 🎤 Final Project + Presentation — **50%**
+## 📚 Student Paper Presentations
+
+### P1 — Nonlinear / Representation Learning in Asset Pricing
+
+Gu, S., Kelly, B., & Xiu, D. (2021). *Autoencoder Asset Pricing Models*. **Journal of Econometrics**.
+
+### P2 — High-Frequency / Microstructure Machine Learning
+
+Kolm, P. N., Turiel, J., & Westray, N. (2023). *Deep Order Flow Imbalance: Extracting Alpha at Multiple Horizons from the Limit Order Book*. **Mathematical Finance**.
+
+### P3 — Portfolio Construction / Decision-Focused Machine Learning
+
+Wang, Z., Gao, J., Harvey, C. R., Liu, Y., & Tao, S. (2026). *Machine Learning Meets Markowitz*. **NBER Working Paper**.
+
+### P4 — Graph Machine Learning for Asset Pricing
+
+Capponi, A., Sidaoui, B., & Zou, Y. (2025/2026). *Graph Machine Learning for Asset Pricing: Traversing the Supply Chain*. **Working paper**.
+
+### P5 — Generative Finance
+
+Huang, X., Chen, Y., & Qiao, X. (2024). *Generative Learning for Financial Time Series with Irregular and Scale-Invariant Patterns*. **ICLR 2024**.
+
+### P6 — Large Language Models in Finance
+
+Lopez-Lira, A., & Tang, Y. (2026). *Can ChatGPT Forecast Stock Price Movements? Return Predictability and Large Language Models*. **Journal of Financial Economics**.
+
+---
+
+## 🎤 Presentation Format
+
+Each group has approximately **30 minutes** for its presentation, followed by **10–15 minutes** of instructor-led discussion.
+
+Suggested presentation structure:
+
+1. **5 min** — Financial question and motivation
+2. **5–7 min** — Data and empirical setup
+3. **8–10 min** — Core methodology
+4. **5 min** — Main empirical results
+5. **5 min** — Critique and possible extensions
+
+Students are not expected to teach the full methodology from scratch. The relevant foundations are covered in the preceding lecture; presentations should focus on understanding, evaluating, and extending the paper.
+
+---
+
+## 🧪 Asset Pricing Homework
+
+The course retains one formal homework, released after Lecture 4 and due after Lecture 10. It covers a complete empirical workflow:
+
+- data preparation,
+- model estimation,
+- validation,
+- out-of-sample prediction, and
+- economic evaluation.
+
+The extended submission window is designed to keep the workload manageable alongside paper presentations and the final research project.
+
+---
+
+## 🧠 Recommended Background
+
+- Finance or economics
+- Machine learning and applied statistics
+- Python programming
 
 ---
 
 ## 🙏 Acknowledgments
 
-My sincere thanks to **Bryan Kelly**, **Renyuan Xu**, and the many researchers who generously shared slides and teaching materials that informed parts of this course. Their scholarship and openness greatly improved the clarity and rigor of several lectures.
+My sincere thanks to **Bryan Kelly**, **Renyuan Xu**, and the many researchers who generously shared slides and teaching materials that informed parts of this course. Their scholarship and openness have improved the clarity and rigor of the lectures.
 
 ---
 
-## 📚 References & Suggested Reading
+## 📖 References and Suggested Reading
+
 - *Financial Machine Learning* — **Kelly & Xiu (2023)**
 - *Advances in Financial Machine Learning* — **López de Prado (2018)**
 - *Recent Advances in RL in Finance* — **Hambly, Xu & Yang (2023)**
 - *The Elements of Financial Econometrics* — **Fan & Yao (2017)**
 - *The Elements of Statistical Learning* — **Hastie, Tibshirani & Friedman (2017)**
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 💹 Machine Learning for Finance (PhD) — Fall 2026
+# 💹 Machine Learning for Finance — Fall 2026
 
-This repository contains materials for the PhD-level course **Machine Learning for Finance**. The course studies modern machine-learning methods for financial prediction and decision-making, with applications to empirical asset pricing, market microstructure, portfolio construction, graph learning, reinforcement learning, generative models, large language models, and responsible AI.
+This repository contains materials for the postgraduate-level course **Machine Learning for Finance**. The course studies modern machine-learning methods for financial prediction and decision-making, with applications to empirical asset pricing, market microstructure, portfolio construction, graph learning, reinforcement learning, generative models, large language models, and responsible AI.
 
 ---
 
@@ -12,7 +12,7 @@ This repository contains materials for the PhD-level course **Machine Learning f
   - 2 hours of instructor lecture
   - 30 minutes of student presentation
   - 10–15 minutes of instructor-led discussion
-- **One formal homework:** Asset Pricing
+- **One formal assignment:** Cross-Sectional Returns
   - Released after **Lecture 4**
   - Due after **Lecture 10**
 - **Lecture 12:** Industry guest lecture / practitioner perspectives
@@ -39,13 +39,13 @@ Fall 2026 lecture files will be added progressively during the semester.
 | **Lec 1** | **Introduction to Financial Machine Learning** — overview, information sets, functional forms, and practical challenges in financial prediction | — |
 | **Lec 2** | **Empirical Asset Pricing I** — data, experimental design, linear and penalized models, and dimension reduction | — |
 | **Lec 3** | **Empirical Asset Pricing II** — trees, ensembles, neural networks, nonlinear models, and alternative data / representation learning | — |
-| **Lec 4** | **High-Frequency Prediction** — limit order books, sampling, order flow, universality, cross-impact, and spatio-temporal modeling | **P1: Nonlinear / Representation Learning in Asset Pricing**; Asset Pricing HW released |
+| **Lec 4** | **High-Frequency Prediction** — limit order books, sampling, order flow, universality, cross-impact, and spatio-temporal modeling | **P1: Nonlinear / Representation Learning in Asset Pricing**; Cross-Sectional Returns Assignment released |
 | **Lec 5** | **Optimal Portfolios** — plug-in vs integrated estimation, covariance estimation, max-Sharpe regression, and transaction costs | **P2: High-Frequency / Microstructure ML** |
 | **Lec 6** | **Graph Machine Learning for Finance** — graph representations, GNNs, financial networks, cross-asset dependence, and covariance / volatility applications | **P3: Portfolio Construction / Decision-Focused ML** |
 | **Lec 7** | **Reinforcement Learning in Finance** — RL basics, optimal execution, market making, and sequential decision-making | **P4: Graph ML for Asset Pricing** |
 | **Lec 8** | **Generative AI for Finance** — GANs, VAEs, diffusion models, synthetic backtesting, Tail-GAN / MARS, and pitfalls | — |
 | **Lec 9** | **Large Language Models for Finance** — sentiment, financial text, report generation, QA / chatbots, reasoning, applications, and challenges | **P5: Generative Finance** |
-| **Lec 10** | **Interpretability & Ethics / Responsible ML** — LIME / SHAP, clustering, t-SNE, bias / fairness, and compliance | **P6: LLMs / Foundation Models in Finance**; Asset Pricing HW due after class |
+| **Lec 10** | **Interpretability & Ethics / Responsible ML** — LIME / SHAP, clustering, t-SNE, bias / fairness, and compliance | **P6: LLMs / Foundation Models in Finance**; Cross-Sectional Returns Assignment due after class |
 | **Lec 11** | **Advanced Topics** — transfer learning, federated learning, microstructure / statistical arbitrage, backtesting pipelines, and selected advanced topics | — |
 | **Lec 12** | **Industry Guest Lecture / Practitioner Perspectives** | Guest speaker discussion |
 | **Lec 13** | **Final Research Presentations** | Student final project presentations |
@@ -80,11 +80,34 @@ Lopez-Lira, A., & Tang, Y. (2026). *Can ChatGPT Forecast Stock Price Movements? 
 
 ---
 
-## 🎤 Presentation Format
+## 🧮 Assessment
 
-Each group has approximately **30 minutes** for its presentation, followed by **10–15 minutes** of instructor-led discussion.
+| Component | Weight |
+|---|---:|
+| Class Participation & Discussion | **10%** |
+| Cross-Sectional Returns Assignment | **20%** |
+| Paper Presentation & Discussion | **20%** |
+| Final Research Project + Presentation | **50%** |
+| **Total** | **100%** |
 
-Suggested presentation structure:
+### 🧪 Cross-Sectional Returns Assignment — 20%
+
+Students apply linear and nonlinear machine-learning models to predict U.S. equity returns. Model performance should be compared using appropriate out-of-sample evaluation, model comparison, and economic interpretation or evaluation.
+
+- **Released:** after Lecture 4
+- **Due:** after Lecture 10
+- This is the only formal assignment in the course.
+
+### 📚 Paper Presentation & Discussion — 20%
+
+Each group presents one assigned research paper related to a course topic.
+
+- **30-minute student presentation**
+- **10–15-minute instructor-led discussion**
+
+Presentations should cover the research question and motivation, methodology, empirical design and data, main results, limitations, and possible extensions. The goal is to critically evaluate the paper's contribution rather than simply summarize it. Students are not expected to teach the methodology from scratch because the relevant foundations are generally covered in the preceding lecture.
+
+A suggested 30-minute structure is:
 
 1. **5 min** — Financial question and motivation
 2. **5–7 min** — Data and empirical setup
@@ -92,21 +115,28 @@ Suggested presentation structure:
 4. **5 min** — Main empirical results
 5. **5 min** — Critique and possible extensions
 
-Students are not expected to teach the full methodology from scratch. The relevant foundations are covered in the preceding lecture; presentations should focus on understanding, evaluating, and extending the paper.
+### 🚀 Final Research Project — 50%
 
----
+Students conduct a research-style project on a topic related to machine learning in finance. Possible directions include:
 
-## 🧪 Asset Pricing Homework
+- asset pricing and portfolio machine learning,
+- high-frequency prediction, trading, and reinforcement learning,
+- graph machine learning for finance,
+- generative models for financial data,
+- large language models in finance, or
+- another instructor-approved topic.
 
-The course retains one formal homework, released after Lecture 4 and due after Lecture 10. It covers a complete empirical workflow:
+Each project should formulate a clear research question and provide at least one methodological extension, careful empirical comparison, or new empirical finding.
 
-- data preparation,
-- model estimation,
-- validation,
-- out-of-sample prediction, and
-- economic evaluation.
+**Deliverables:**
 
-The extended submission window is designed to keep the workload manageable alongside paper presentations and the final research project.
+- code or reproducible analysis,
+- final report, and
+- in-class presentation.
+
+### 🗣️ Class Participation & Discussion — 10%
+
+Active participation in lectures, paper discussions, and class activities is expected throughout the course.
 
 ---
 


### PR DESCRIPTION
## What changed

- Updated the repository README for the Fall 2026 postgraduate course.
- Added the revised 13-lecture schedule and six student paper presentations.
- Added the assessment structure: participation 10%, Cross-Sectional Returns assignment 20%, paper presentation and discussion 20%, and final research project 50%.
- Added assignment expectations, presentation format, project directions, and deliverables.
- Added `docs/lectures_Fall2026/` with only a `.gitkeep` placeholder.
- Preserved links to the Spring 2025 and Spring 2026 archives.

## Validation

- Re-read the README from the remote branch.
- Confirmed the README contains no `PhD` wording and uses `postgraduate-level`.
- Confirmed all assessment weights and the 100% total are present.
- Compared the branch against `main`; only `README.md` and `docs/lectures_Fall2026/.gitkeep` changed.
- No lecture slides, assignments, papers, or other course files were uploaded.